### PR TITLE
Switch from nvidia/cuda to plain ubuntu:22.05 base image

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,5 +1,5 @@
-# CUDA 12.6 + cuDNN devel (Ubuntu 22.04)
-FROM nvidia/cuda:12.8.1-cudnn-devel-ubuntu22.04
+# Standard Ubuntu base image.  CUDA base images not needed.
+FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive \
     PYTHONUNBUFFERED=1 \
@@ -26,10 +26,18 @@ RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.10 1 \
 # ---- No cuDNN repo meddling needed if using TF 2.17.x ----
 
 # Python deps
+# Order is important. onnxruntime, tensorflow and torch have
+# to be installed in the order below or their cuda dependencies
+# will conflict.
 COPY requirements.txt /tmp/requirements.txt
 RUN pip install --upgrade pip \
  && pip install "numpy==1.26.4" "cython>=0.29.36" \
  && pip install -r /tmp/requirements.txt \
+ && pip install "onnxruntime-gpu[cuda]>=1.16.0" \
+ && pip install "tensorflow[and-cuda]==2.18.0" \
+    "tensorboard==2.18.0" \
+    "tensorboard-data-server==0.7.2" \
+    "tensorflow-io-gcs-filesystem==0.37.1" \
  && pip install \
       torch==2.7.1 \
       torchaudio==2.7.1 \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,5 @@
 # --- Core training (Microwakeword) ---
 
-# TensorFlow stack (match CUDA/cuDNN in the base image)
-tensorflow==2.17.1
-tensorboard==2.17.1
-tensorboard-data-server==0.7.2
-tensorflow-io-gcs-filesystem==0.37.1
-# tensorflow-estimator not needed (remove)
-
 numpy==1.26.4
 scipy==1.12.0
 librosa==0.10.2.post1
@@ -25,7 +18,6 @@ bitstruct==8.19.0
 
 # --- Piper sample generation ---
 piper-tts>=1.2.0
-onnxruntime-gpu>=1.16.0
 piper-phonemize-cross==1.2.1
 
 # --- Notebook / tooling ---


### PR DESCRIPTION
Since this is a pure Python environment, the CUDA toolkit isn't really
necessary. The various Python packages that can use CUDA will download
and install the CUDA dependencies they need.  This shaves off at least
8gb from the final image.

The Python package install order needed to be tweaked to ensure onnxruntime,
tensorflow and torch are installed in that order.  Any other order results
in dependent cuda package clashes.

Resolves: #12
